### PR TITLE
Turn on ssh password auth

### DIFF
--- a/doc_source/amazon-linux-2-virtual-machine.md
+++ b/doc_source/amazon-linux-2-virtual-machine.md
@@ -56,7 +56,7 @@ Use the Amazon Linux 2 virtual machine images for on\-premises development and t
           ssh-authorized-keys:
                   - ssh-public-key-information
           lock_passwd: true
-      
+      ssh_pwauth: True
       chpasswd:
         list: |
           ec2-user:plain-text-password


### PR DESCRIPTION
Amazon linux turns ssh password authentication off for the default configuration. we need to turn it on to be able to login. Without this line no login using the password is possible (Tested on latest amzn2-virtualbox-2017.12.0.20180222-x86_64.xfs.gpt.vdi)
ssh_pwauth: True

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
