### PR TITLE
Patch 1

### DIFF
--- a/doc_source/spot-interruptions.md
+++ b/doc_source/spot-interruptions.md
@@ -163,6 +163,9 @@ The following example indicates that hibernation has started immediately:
 ```
 {"action": "hibernate", "time": "2017-11-28T08:22:00Z"}
 ```
+If Amazon EC2 is not preparing to be hibernated, stopped, or terminated by the Spot service, or if you terminated the Spot Instance yourself, the instance-action item is not present (so you receive an HTTP 404 error).
+
+See this example for a (Bash script to continueslly monitors instance-action)[https://github.com/awslabs/ec2-spot-labs/blob/master/sqs-ec2-spot-fleet-autoscaling/spot-instance-interruption-notice-handler.sh].
 
 ### termination\-time<a name="termination-time-metadata"></a>
 

--- a/doc_source/spot-interruptions.md
+++ b/doc_source/spot-interruptions.md
@@ -165,7 +165,7 @@ The following example indicates that hibernation has started immediately:
 ```
 If Amazon EC2 is not preparing to be hibernated, stopped, or terminated by the Spot service, or if you terminated the Spot Instance yourself, the instance-action item is not present (so you receive an HTTP 404 error).
 
-See this example for a (Bash script to continueslly monitors instance-action)[https://github.com/awslabs/ec2-spot-labs/blob/master/sqs-ec2-spot-fleet-autoscaling/spot-instance-interruption-notice-handler.sh].
+See this example for a [Bash script to continueslly monitors instance-action](https://github.com/awslabs/ec2-spot-labs/blob/master/sqs-ec2-spot-fleet-autoscaling/spot-instance-interruption-notice-handler.sh).
 
 ### termination\-time<a name="termination-time-metadata"></a>
 

--- a/doc_source/spot-interruptions.md
+++ b/doc_source/spot-interruptions.md
@@ -140,7 +140,7 @@ The following is an example of the event for Spot Instance interruption\. The po
 
 ### instance\-action<a name="instance-action-metadata"></a>
 
-If your Spot Instance is marked to be hibernated, stopped, or terminated by the Spot service, the `instance-action` item is present in your instance metadata\. You can retrieve `instance-action` as follows\.
+If your Spot Instance is marked to be hibernated, stopped, or terminated by the Spot service, the `instance-action` item is present in your instance metadata\. Otherwise, it is not present. You can retrieve `instance-action` as follows\.
 
 ```
 [ec2-user ~]$ curl http://169.254.169.254/latest/meta-data/spot/instance-action
@@ -163,13 +163,13 @@ The following example indicates that hibernation has started immediately:
 ```
 {"action": "hibernate", "time": "2017-11-28T08:22:00Z"}
 ```
-If Amazon EC2 is not preparing to be hibernated, stopped, or terminated by the Spot service, or if you terminated the Spot Instance yourself, the instance-action item is not present (so you receive an HTTP 404 error).
-
-See this example for a [Bash script to continueslly monitors instance-action](https://github.com/awslabs/ec2-spot-labs/blob/master/sqs-ec2-spot-fleet-autoscaling/spot-instance-interruption-notice-handler.sh).
+If Amazon EC2 is not preparing to hibernate, stop, or terminate the instance, or if you terminated the instance yourself, the `instance-action` item is not present and you receive an HTTP 404 error\.
 
 ### termination\-time<a name="termination-time-metadata"></a>
 
-If your Spot Instance is marked for termination by the Spot service, the `termination-time` item is present in your instance metadata\. This item is maintained for backward compatibility; you should use `instance-action` instead\. You can retrieve `termination-time` as follows\.
+This item is maintained for backward compatibility; you should use `instance-action` instead\.
+
+If your Spot Instance is marked for termination by the Spot service, the `termination-time` item is present in your instance metadata\. Otherwise, it is not present. You can retrieve `termination-time` as follows\.
 
 ```
 [ec2-user ~]$ if curl -s http://169.254.169.254/latest/meta-data/spot/termination-time | grep -q .*T.*Z; then echo terminated; fi
@@ -181,6 +181,6 @@ The `termination-time` item specifies the approximate time in UTC when the insta
 2015-01-05T18:02:00Z
 ```
 
-If Amazon EC2 is not preparing to terminate the instance, or if you terminated the Spot Instance yourself, the `termination-time` item is either not present \(so you receive an HTTP 404 error\) or contains a value that is not a time value\.
+If Amazon EC2 is not preparing to terminate the instance, or if you terminated the instance yourself, the `termination-time` item is either not present \(so you receive an HTTP 404 error\) or contains a value that is not a time value\.
 
 If Amazon EC2 fails to terminate the instance, the request status is set to `fulfilled`\. Note that `termination-time` remains in the instance metadata with the original approximate time, which is now in the past\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
1. Added a clarification that when Spot isn't terminating a user should expect to get a 404 HTTP response when accessing http://169.254.169.254/latest/meta-data/spot/instance-action (the same is noted for the not-recommended-anymore termination-time item).
2. Also most users will need to write some script to continuously monitor instance-action. This is a difficult and error-prone script to write because it's hard to simulate a non 404 response (spot is terminating). Therefore I'm providing a basic script the user can build off of. The script is from https://github.com/awslabs and is therefore credible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
