### PR TITLE
Ubuntu: Update supported versions and default user=

### DIFF
--- a/doc_source/AccessingInstancesLinux.md
+++ b/doc_source/AccessingInstancesLinux.md
@@ -35,7 +35,7 @@ Before you connect to your Linux instance, complete the following prerequisites:
   + For a Fedora AMI, the user name is `ec2-user` or `fedora`\.
   + For a RHEL AMI, the user name is `ec2-user` or `root`\.
   + For a SUSE AMI, the user name is `ec2-user` or `root`\.
-  + For an Ubuntu AMI, the user name is `ubuntu` or `root`\.
+  + For an Ubuntu AMI, the user name is `ubuntu`\.
   + Otherwise, if `ec2-user` and `root` don't work, check with the AMI provider\.
 + **Enable inbound SSH traffic from your IP address to your instance**
 
@@ -123,7 +123,7 @@ One way to transfer files between your local computer and a Linux instance is to
   + For a Fedora AMI, the user name is `ec2-user` or `fedora`\.
   + For a RHEL AMI, the user name is `ec2-user` or `root`\.
   + For a SUSE AMI, the user name is `ec2-user` or `root`\.
-  + For an Ubuntu AMI, the user name is `ubuntu` or `root`\.
+  + For an Ubuntu AMI, the user name is `ubuntu`\.
   + Otherwise, if `ec2-user` and `root` don't work, check with the AMI provider\.
 + **Enable inbound SSH traffic from your IP address to your instance**
 

--- a/doc_source/TroubleshootingInstancesConnecting.md
+++ b/doc_source/TroubleshootingInstancesConnecting.md
@@ -132,7 +132,7 @@ In PuTTYgen, load your private key file and select **Save Private Key** rather t
   + For a Fedora AMI, the user name is `ec2-user` or `fedora`\.
   + For a RHEL AMI, the user name is `ec2-user` or `root`\.
   + For a SUSE AMI, the user name is `ec2-user` or `root`\.
-  + For an Ubuntu AMI, the user name is `ubuntu` or `root`\.
+  + For an Ubuntu AMI, the user name is `ubuntu`\.
   + Otherwise, if `ec2-user` and `root` don't work, check with the AMI provider\.
 + Verify that you have an inbound security group rule to allow inbound traffic to the appropriate port\. For more information, see [Authorizing Network Access to Your Instances](authorizing-access-to-an-instance.md)\. 
 
@@ -147,7 +147,7 @@ The appropriate user names are as follows:
 + For a Fedora AMI, the user name is `ec2-user` or `fedora`\.
 + For a RHEL AMI, the user name is `ec2-user` or `root`\.
 + For a SUSE AMI, the user name is `ec2-user` or `root`\.
-+ For an Ubuntu AMI, the user name is `ubuntu` or `root`\.
++ For an Ubuntu AMI, the user name is `ubuntu`\.
 + Otherwise, if `ec2-user` and `root` don't work, check with the AMI provider\.
 
 For example, to use an SSH client to connect to an instance launched from an Amazon Linux AMI, use the following command:
@@ -226,7 +226,7 @@ The appropriate user names are as follows:
 + For a Fedora AMI, the user name is `ec2-user` or `fedora`\.
 + For a RHEL AMI, the user name is `ec2-user` or `root`\.
 + For a SUSE AMI, the user name is `ec2-user` or `root`\.
-+ For an Ubuntu AMI, the user name is `ubuntu` or `root`\.
++ For an Ubuntu AMI, the user name is `ubuntu`\.
 + Otherwise, if `ec2-user` and `root` don't work, check with the AMI provider\.
 
 You should also verify that your private key \(\.pem\) file has been correctly converted to the format recognized by PuTTY \(\.ppk\)\. For more information about converting your private key, see [Connecting to Your Linux Instance from Windows Using PuTTY](putty.md)\.

--- a/doc_source/managing-users.md
+++ b/doc_source/managing-users.md
@@ -1,6 +1,6 @@
 # Managing User Accounts on Your Linux Instance<a name="managing-users"></a>
 
-Each Linux instance type launches with a default Linux system user account\. For Amazon Linux, the user name is `ec2-user`\. For Centos, the user name is `centos`\. For Debian, the user name is `admin` or `root`\. For Fedora, the user name is `ec2-user` or `fedora`\. For RHEL, the user name is `ec2-user` or `root`\. For SUSE, the user name is `ec2-user` or `root`\. For Ubuntu, the user name is `ubuntu` or `root`\. Otherwise, if `ec2-user` and `root` don't work, check with your AMI provider\.
+Each Linux instance type launches with a default Linux system user account\. For Amazon Linux, the user name is `ec2-user`\. For Centos, the user name is `centos`\. For Debian, the user name is `admin` or `root`\. For Fedora, the user name is `ec2-user` or `fedora`\. For RHEL, the user name is `ec2-user` or `root`\. For SUSE, the user name is `ec2-user` or `root`\. For Ubuntu, the user name is `ubuntu`\. Otherwise, if `ec2-user` and `root` don't work, check with your AMI provider\.
 
 **Note**  
 Linux system users should not be confused with AWS Identity and Access Management \(IAM\) users\. For more information, see [IAM Users and Groups](http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_WorkingWithGroupsAndUsers.html) in the *IAM User Guide*\.

--- a/doc_source/memory-optimized-instances.md
+++ b/doc_source/memory-optimized-instances.md
@@ -121,7 +121,7 @@ Memory optimized instances provide a high number of vCPUs, which can cause launc
 
 The following AMIs support launching Memory optimized instances:
 + Amazon Linux AMI 2016\.03 \(HVM\) or later
-+ Ubuntu Server 14\.04 LTS \(HVM\)
++ Ubuntu Server 14\.04 LTS \(HVM\) or later
 + Red Hat Enterprise Linux 7\.1 \(HVM\)
 + SUSE Linux Enterprise Server 12 SP1 \(HVM\)
 + Windows Server 2016

--- a/doc_source/mindterm.md
+++ b/doc_source/mindterm.md
@@ -27,7 +27,7 @@ The Chrome browser does not support the NPAPI plugin, and therefore cannot run t
   + For a Fedora AMI, the user name is `ec2-user` or `fedora`\.
   + For a RHEL AMI, the user name is `ec2-user` or `root`\.
   + For a SUSE AMI, the user name is `ec2-user` or `root`\.
-  + For an Ubuntu AMI, the user name is `ubuntu` or `root`\.
+  + For an Ubuntu AMI, the user name is `ubuntu`\.
   + Otherwise, if `ec2-user` and `root` don't work, check with the AMI provider\.
 + **Enable inbound SSH traffic from your IP address to your instance**
 
@@ -52,7 +52,7 @@ The Chrome browser does not support the NPAPI plugin, and therefore cannot run t
       + For a Fedora AMI, the user name is `ec2-user` or `fedora`\.
       + For a RHEL AMI, the user name is `ec2-user` or `root`\.
       + For a SUSE AMI, the user name is `ec2-user` or `root`\.
-      + For an Ubuntu AMI, the user name is `ubuntu` or `root`\.
+      + For an Ubuntu AMI, the user name is `ubuntu`\.
       + Otherwise, if `ec2-user` and `root` don't work, check with the AMI provider\.
 
    1. In **Private key path**, enter the fully qualified path to your private key \(`.pem`\) file, including the key pair name; for example:

--- a/doc_source/putty.md
+++ b/doc_source/putty.md
@@ -32,7 +32,7 @@ Before you connect to your Linux instance using PuTTY, complete the following pr
   + For a Fedora AMI, the user name is `ec2-user` or `fedora`\.
   + For a RHEL AMI, the user name is `ec2-user` or `root`\.
   + For a SUSE AMI, the user name is `ec2-user` or `root`\.
-  + For an Ubuntu AMI, the user name is `ubuntu` or `root`\.
+  + For an Ubuntu AMI, the user name is `ubuntu`\.
   + Otherwise, if `ec2-user` and `root` don't work, check with the AMI provider\.
 + **Enable inbound SSH traffic from your IP address to your instance**
 
@@ -97,7 +97,7 @@ Use the following procedure to connect to your Linux instance using PuTTY\. You 
       + For a Fedora AMI, the user name is `ec2-user` or `fedora`\.
       + For a RHEL AMI, the user name is `ec2-user` or `root`\.
       + For a SUSE AMI, the user name is `ec2-user` or `root`\.
-      + For an Ubuntu AMI, the user name is `ubuntu` or `root`\.
+      + For an Ubuntu AMI, the user name is `ubuntu`\.
       + Otherwise, if `ec2-user` and `root` don't work, check with the AMI provider\.
 
    1. \(IPv6 only\) To connect using your instance's IPv6 address, enter *user\_name*@*ipv6\_address*\. Be sure to specify the appropriate user name for your AMI\. For example:
@@ -107,7 +107,7 @@ Use the following procedure to connect to your Linux instance using PuTTY\. You 
       + For a Fedora AMI, the user name is `ec2-user` or `fedora`\.
       + For a RHEL AMI, the user name is `ec2-user` or `root`\.
       + For a SUSE AMI, the user name is `ec2-user` or `root`\.
-      + For an Ubuntu AMI, the user name is `ubuntu` or `root`\.
+      + For an Ubuntu AMI, the user name is `ubuntu`\.
       + Otherwise, if `ec2-user` and `root` don't work, check with the AMI provider\.
 
    1. Under **Connection type**, select **SSH**\.
@@ -177,7 +177,7 @@ WinSCP is a GUI\-based file manager for Windows that allows you to upload and tr
    + For a Fedora AMI, the user name is `ec2-user` or `fedora`\.
    + For a RHEL AMI, the user name is `ec2-user` or `root`\.
    + For a SUSE AMI, the user name is `ec2-user` or `root`\.
-   + For an Ubuntu AMI, the user name is `ubuntu` or `root`\.
+   + For an Ubuntu AMI, the user name is `ubuntu`\.
    + Otherwise, if `ec2-user` and `root` don't work, check with the AMI provider\.
 
 1. Specify the private key for your instance\. For **Private key**, enter the path to your private key, or choose the "**\.\.\.**" button to browse for the file\. For newer versions of WinSCP, choose **Advanced** to open the advanced site settings and then under **SSH**, choose **Authentication** to find the **Private key file** setting\.

--- a/doc_source/storage-optimized-instances.md
+++ b/doc_source/storage-optimized-instances.md
@@ -141,7 +141,7 @@ The `d2.8xlarge` instance type provides 36 vCPUs, which might cause launch issue
 
 The following Linux AMIs support launching `d2.8xlarge` instances with 36 vCPUs:
 + Amazon Linux AMI 2018\.03 \(HVM\)
-+ Ubuntu Server 14\.04 LTS \(HVM\)
++ Ubuntu Server 14\.04 LTS \(HVM\) or later
 + Red Hat Enterprise Linux 7\.1 \(HVM\)
 + SUSE Linux Enterprise Server 12 \(HVM\)
 


### PR DESCRIPTION
No supported releases ship with root ssh login enabled.  This patch removes 'root' as an ssh user for Ubuntu wherever mentioned.  No supported release of Ubuntu ships with this user enabled by default for ssh.  The 'ubuntu' user is the only user enabled by default in the Ubuntu AMIs.

For Ubuntu releases note "or later" where appropriate.  Where Ubuntu releases are mentioned regarding EC2 feature support this patch adds 'or later' where appropriate in include later OS releases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
