### PR TITLE
Update iam-roles-for-amazon-ec2.md

### DIFF
--- a/doc_source/iam-roles-for-amazon-ec2.md
+++ b/doc_source/iam-roles-for-amazon-ec2.md
@@ -28,7 +28,7 @@ You can apply resource\-level permissions to your IAM policies to control the us
 
 ## Instance Profiles<a name="ec2-instance-profile"></a>
 
-Amazon EC2 uses an *instance profile* as a container for an IAM role\. When you create an IAM role using the IAM console, the console creates an instance profile automatically and gives it the same name as the role to which it corresponds\. If you use the Amazon EC2 console to launch an instance with an IAM role or to attach an IAM role to an instance, you choose the instance based on a list of instance profile names\. 
+Amazon EC2 uses an *instance profile* as a container for an IAM role\. When you create an IAM role using the IAM console, the console creates an instance profile automatically and gives it the same name as the role to which it corresponds\. If you use the Amazon EC2 console to launch an instance with an IAM role or to attach an IAM role to an instance, you choose the role based on a list of instance profile names\. 
 
 If you use the AWS CLI, API, or an AWS SDK to create a role, you create the role and instance profile as separate actions, with potentially different names\. If you then use the AWS CLI, API, or an AWS SDK to launch an instance with an IAM role or to attach an IAM role to an instance, specify the instance profile name\. 
 


### PR DESCRIPTION
Fixing use of nouns in the first paragraph for "instance profiles".

Feel free to follow up with me if you disagree.

*Issue #, if available:*

*Description of changes:* replace the noun "instance" by "role" in the last clause, for the first paragraph in the section "Instance Profiles".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
