### PR TITLE
Clarified Billing for Reserved Instances

### DIFF
--- a/doc_source/ec2-instance-lifecycle.md
+++ b/doc_source/ec2-instance-lifecycle.md
@@ -22,7 +22,7 @@ The table indicates billing for instance usage only\. Some AWS resources, such a
 |  `terminated`  |  The instance has been permanently deleted and cannot be restarted\.  |  Not billed  | 
 
 **Note**  
-Rebooting an instance doesn't start a new instance billing period because the instance stays in the `running` state\.
+Rebooting an instance doesn't start a new instance billing period because the instance stays in the `running` state\. If you are using Reserved Instances, take note that even if you terminate the instance, you will still be billed until the end of your Reserved Instance contract.
 
 ## Instance Launch<a name="instance-launch"></a>
 


### PR DESCRIPTION
The row in the Instance Usage Billing table, which says `terminated` instances are not billed any longer, is not entirely true. If the user is using a Reserved Instance, then they are still billed until the end of their Reserved Instance contract.

This information is quite important as people might assume that they can prematurely cancel their Reserved Instances by simply terminating their instance.

As per your knowledge brief: 
"Reserved Instances are billed each month for each hour in a given month until the end of the Reserved Instance contract."

Reference: 
https://aws.amazon.com/premiumsupport/knowledge-center/ec2-billing-terminated/


*Issue #, if available:* Missing information about the billing for Reserved Instances when the instance terminates.

*Description of changes:* Added a note about Reserved Instance billing 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
