### PR TITLE
Update sriov-networking.md

### DIFF
--- a/doc_source/sriov-networking.md
+++ b/doc_source/sriov-networking.md
@@ -179,7 +179,7 @@ The following procedure provides the general steps for compiling the `ixgbevf` m
    ubuntu:~$ sudo apt-get update && sudo apt-get upgrade -y linux-aws
    ```
 **Important**  
-If during the update process, you are prompted to install `grub`, use `/dev/xvda` to install `grub` onto, and then choose to keep the current version of `/boot/grub/menu.lst`\.
+If during the update process, you are prompted to install `grub`, use `/dev/xvda` to install `grub`, and then choose to keep the current version of `/boot/grub/menu.lst`\.
 
 ## Enabling Enhanced Networking on Other Linux Distributions<a name="enhanced-networking-linux"></a>
 


### PR DESCRIPTION
*Description of changes:*

> use `/dev/xvda` to install `grub` onto

Onto what? Not sure what should be here, proposing removing it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
