### PR TITLE
Update ec2-key-pairs.md

### DIFF
--- a/doc_source/ec2-key-pairs.md
+++ b/doc_source/ec2-key-pairs.md
@@ -332,7 +332,7 @@ The device name may appear differently on your instance\. For example, devices m
 
    1. Mount the volume \(or partition\) at the temporary mount point, using the volume name or device name you identified earlier\.
    
-   Note: "-o nouuid" is only valid on XFS file systems, which include Red Hat (or varients, such as CentOS or Amazon Linux).
+   **Note** "-o nouuid" is only valid on XFS file systems, which include Red Hat (or varients, such as CentOS or Amazon Linux).
    On ext4 file systems, omit this option. This includes systems such as Debian or Ubuntu.
 
       ```

--- a/doc_source/ec2-key-pairs.md
+++ b/doc_source/ec2-key-pairs.md
@@ -330,7 +330,8 @@ The device name may appear differently on your instance\. For example, devices m
       [ec2-user ~]$ sudo mkdir /mnt/tempvol
       ```
 
-   1. Mount the volume \(or partition\) at the temporary mount point, using the volume name or device name you identified earlier\. **Note** "-o nouuid" is only valid on XFS file systems, which include Red Hat (or varients, such as CentOS or Amazon Linux).
+   1. Mount the volume \(or partition\) at the temporary mount point, using the volume name or device name you identified earlier\. **Note** 
+"-o nouuid" is only valid on XFS file systems, which include Red Hat (or varients, such as CentOS or Amazon Linux).
    On ext4 file systems, omit this option. This includes systems such as Debian or Ubuntu.
 
       ```

--- a/doc_source/ec2-key-pairs.md
+++ b/doc_source/ec2-key-pairs.md
@@ -331,9 +331,11 @@ The device name may appear differently on your instance\. For example, devices m
       ```
 
    1. Mount the volume \(or partition\) at the temporary mount point, using the volume name or device name you identified earlier\.
+   Note: "-o nouuid" is only valid on XFS file systems, which include Red Hat (or varients, such as CentOS or Amazon Linux).
+   On ext4 file systems, omit this option. This includes systems such as Debian or Ubuntu.
 
       ```
-      [ec2-user ~]$ sudo mount -o nouuid /dev/xvdf1 /mnt/tempvol
+      [ec2-user ~]$ sudo mount [-o nouuid] /dev/xvdf1 /mnt/tempvol
       ```
 
 1. From the temporary instance, use the following command to update `authorized_keys` on the mounted volume with the new public key from the `authorized_keys` for the temporary instance\.

--- a/doc_source/ec2-key-pairs.md
+++ b/doc_source/ec2-key-pairs.md
@@ -331,6 +331,7 @@ The device name may appear differently on your instance\. For example, devices m
       ```
 
    1. Mount the volume \(or partition\) at the temporary mount point, using the volume name or device name you identified earlier\.
+   
    Note: "-o nouuid" is only valid on XFS file systems, which include Red Hat (or varients, such as CentOS or Amazon Linux).
    On ext4 file systems, omit this option. This includes systems such as Debian or Ubuntu.
 

--- a/doc_source/ec2-key-pairs.md
+++ b/doc_source/ec2-key-pairs.md
@@ -330,9 +330,7 @@ The device name may appear differently on your instance\. For example, devices m
       [ec2-user ~]$ sudo mkdir /mnt/tempvol
       ```
 
-   1. Mount the volume \(or partition\) at the temporary mount point, using the volume name or device name you identified earlier\.
-   
-   **Note** "-o nouuid" is only valid on XFS file systems, which include Red Hat (or varients, such as CentOS or Amazon Linux).
+   1. Mount the volume \(or partition\) at the temporary mount point, using the volume name or device name you identified earlier\. **Note** "-o nouuid" is only valid on XFS file systems, which include Red Hat (or varients, such as CentOS or Amazon Linux).
    On ext4 file systems, omit this option. This includes systems such as Debian or Ubuntu.
 
       ```


### PR DESCRIPTION
*Issue #, if available:*
The option `-o nouuid` to mount a device doesn't exist on Ubuntu and Debian systems and using it results in an error, this is not mentioned in the docs. 

*Description of changes:*
Mentioned not to use `-o nouuid` when trying to mount a device on Ubuntu and Debian systems. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.