### PR TITLE
Add info on how an outage in one of the AZs can affect overall Spot capacity

### DIFF
--- a/doc_source/spot-bid-status.md
+++ b/doc_source/spot-bid-status.md
@@ -27,7 +27,7 @@ As soon as you make a Spot Instance request, it goes into the `pending-evaluatio
 **Holding**  
 If one or more request constraints are valid but can't be met yet, or if there is not enough capacity, the request goes into a holding state waiting for the constraints to be met\. The request options affect the likelihood of the request being fulfilled\. For example, if you specify a maximum price below the current Spot price, your request stays in a holding state until the Spot price goes below your maximum price\. If you specify an Availability Zone group, the request stays in a holding state until the Availability Zone constraint is met\.
 
-In the event of an outage of one of the Availability Zones, there is a chance that the capacity for Spot instances in other Availability Zones can be affected\.
+In the event of an outage of one of the Availability Zones, there is a chance that the spare EC2 capacity available for Spot instance requests in other Availability Zones can be affected\.
 
 
 | Status Code | Request State | Instance State | 

--- a/doc_source/spot-bid-status.md
+++ b/doc_source/spot-bid-status.md
@@ -27,6 +27,8 @@ As soon as you make a Spot Instance request, it goes into the `pending-evaluatio
 **Holding**  
 If one or more request constraints are valid but can't be met yet, or if there is not enough capacity, the request goes into a holding state waiting for the constraints to be met\. The request options affect the likelihood of the request being fulfilled\. For example, if you specify a maximum price below the current Spot price, your request stays in a holding state until the Spot price goes below your maximum price\. If you specify an Availability Zone group, the request stays in a holding state until the Availability Zone constraint is met\.
 
+In the event of an outage of one of the Availability Zones, there is a chance that the capacity for Spot instances in other Availability Zones can be affected\.
+
 
 | Status Code | Request State | Instance State | 
 | --- | --- | --- | 


### PR DESCRIPTION
Hi Team,

I would like to propose to add more information on how an outage in one of the AZs in an AWS region can affect the availability of the Spot capacity of the other AZs. Basically, the idea is that if there is an outage in one of the AZs, then there would be a surge of Spot requests to the other running AZs, to fill the gap, which can then affect the overall Spot capacity of the entire region. 

Honestly, I am not quite sure if this is the correct behavior but I received some information that there are some official AWS training classes, like the Exam Readiness: AWS Certified Solutions Architect – Professional course, which describes the above scenario. Reference: https://aws.amazon.com/about-aws/whats-new/2018/06/exam-readiness-courses/

I checked the official AWS FAQ and EC2 Troubleshooting guide but I haven't seen any information about this. The main purpose of this is to have ample information for those companies that have a production environment which completely uses auto-scaled Spot Instances deployed to multiple AZs. I have been working with a lot of cloud-based companies here in Sydney and I see that some of them have this kind of architecture. The justification of my fellow architects is that the outage of an AZ is isolated to another AZ, which is why the Spot capacity should not be affected. But of course, there is also a certain logic that the Spot Requests can be redirected to another AZs.

Thank you in advance for your help in clarifying this issue. Looking forward to your reply.

Cheers,
Jon Bonso


*Issue #, if available:*  Lack of info on how an outage in one AZ can affect the Spot Capacity of the other AZs

*Description of changes:* Added information


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
