### PR TITLE
Update AccessingInstancesLinux.md

### DIFF
--- a/doc_source/AccessingInstancesLinux.md
+++ b/doc_source/AccessingInstancesLinux.md
@@ -155,7 +155,7 @@ The following procedure steps you through using SCP to transfer a file\. If you'
 1. Transfer a file to your instance using the instance's public DNS name\. For example, if the name of the private key file is `my-key-pair`, the file to transfer is `SampleFile.txt`, the user name is `ec2-user`, and the public DNS name of the instance is `ec2-198-51-100-1.compute-1.amazonaws.com`, use the following command to copy the file to the `ec2-user` home directory\.
 
    ```
-   scp -i /path/my-key-pair.pem /path/SampleFile.txt ec2-user@c2-198-51-100-1.compute-1.amazonaws.com:~
+   scp -i /path/my-key-pair.pem /path/SampleFile.txt ec2-user@ec2-198-51-100-1.compute-1.amazonaws.com:~
    ```
 
    You see a response like the following:


### PR DESCRIPTION
Doesnt the public DNS name of an instance start with `ec2-...` and not `c2-...`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
