### PR TITLE
s/temp/tmp for viewing logs

### DIFF
--- a/doc_source/ec2rl_working.md
+++ b/doc_source/ec2rl_working.md
@@ -37,7 +37,7 @@ For example, this command runs the dig module to query the `amazon.com` domain:
 ```
 
 **Example Example: View the results**  
-You can view the results in `/var/temp/ec2rl`:  
+You can view the results in `/var/tmp/ec2rl`:
 
 ```
 cat /var/tmp/ec2rl/logfile_location


### PR DESCRIPTION
The documentation for EC2 Rescue for Linux contains a reference to `/var/temp`, a location on the file system that would not exist by default. This reference is contained in a sentence explaining what the command immediately after the explanatory sentence does.

Fixes that, to ensure both correctness but also consistency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
