### PR TITLE
only upgrade linux-aws

### DIFF
--- a/doc_source/nvme-ebs-volumes.md
+++ b/doc_source/nvme-ebs-volumes.md
@@ -47,7 +47,7 @@ If you are using an AMI that does not include the NVMe driver, you can install t
 1. Ubuntu 16\.04 and later include the `linux-aws` package, which contains the NVMe and ENA drivers required by Nitro\-based instances\. Upgrade the `linux-aws` package to receive the latest version as follows:
 
    ```
-   [ec2-user ~]$ sudo apt-get upgrade -y linux-aws
+   [ec2-user ~]$ sudo apt-get install --only-upgrade -y linux-aws
    ```
 
    For Ubuntu 14\.04, you can install the latest `linux-aws` package as follows:


### PR DESCRIPTION
for Ubuntu 16.04 and later, carelessly upgrading every AWS package may have unintended consequences. It is advisable to only upgrade the linux-aws package.

*Issue #, if available:*
All packages are updated, which isn't the intended result

*Description of changes:*
upgrade-only the package that needs upgrades, not every Ubuntu package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
