### PR TITLE
Add Cape Town to Region table

### DIFF
--- a/doc_source/using-regions-availability-zones.md
+++ b/doc_source/using-regions-availability-zones.md
@@ -96,6 +96,7 @@ The following table lists the Regions provided by an AWS account\. You can't des
 |  `us-east-1`  |  US East \(N\. Virginia\)  | Not required | No | 
 |  `us-west-1`  |  US West \(N\. California\)  | Not required | No | 
 |  `us-west-2`  |  US West \(Oregon\)  | Not required | Yes \- us\-west\-2\-lax\-1a You must enable the Local Zone\. | 
+|  `af-south-1` |  Africa (Cape Town)  | Required | No | 
 |  `ap-east-1`  |  Asia Pacific \(Hong Kong\)  | Required | No | 
 |  `ap-south-1`  |  Asia Pacific \(Mumbai\)  | Not required | No | 
 |  `ap-northeast-3`  |  Asia Pacific \(Osaka\-Local\)  | Not required | No | 


### PR DESCRIPTION
Adds the `af-south-1` (Cape Town) region to the list of regions.

This region is present on the documentation website (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html), but wasn't present yet here - so I'm guessing this repo is not the source of truth.

The Opt-In status is set to 'Required', following this blogpost: https://aws.amazon.com/blogs/security/setting-permissions-to-enable-accounts-for-upcoming-aws-regions/
This is also confirmed by my personal AWS account, where I need to opt-in for Cape Town.

The documentation website lists Cape Town as Opt-In: Not required, so that might be a mistake?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
