### PR TITLE
Update Stop_Start.md

### DIFF
--- a/doc_source/Stop_Start.md
+++ b/doc_source/Stop_Start.md
@@ -23,7 +23,7 @@ When you stop a running instance, the following happens:
 + The instance performs a normal shutdown and stops running; its status changes to `stopping` and then `stopped`\.
 + Any Amazon EBS volumes remain attached to the instance, and their data persists\.
 + Any data stored in the RAM of the host computer or the instance store volumes of the host computer is gone\.
-+ In most cases, the instance is migrated to a new underlying host computer when it's started\. Note: Your instance might stay on the same host computer if there are no problems with the host computer.
++ In most cases, the instance is migrated to a new underlying host computer when it's started (though in some cases, it remains on the current host)\. 
 + The instance retains its private IPv4 addresses and any IPv6 addresses when stopped and started\. We release the public IPv4 address and assign a new one when you start it\.
 + The instance retains its associated Elastic IP addresses\. You're charged for any Elastic IP addresses associated with a stopped instance\. With EC2\-Classic, an Elastic IP address is dissociated from your instance when you stop it\. For more information, see [EC2\-Classic](ec2-classic-platform.md)\.
 + When you stop and start a Windows instance, the EC2Config service performs tasks on the instance, such as changing the drive letters for any attached Amazon EBS volumes\. For more information about these defaults and how you can change them, see [Configuring a Windows instance using the EC2Config service](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2config-service.html) in the *Amazon EC2 User Guide for Windows Instances*\.

--- a/doc_source/Stop_Start.md
+++ b/doc_source/Stop_Start.md
@@ -23,7 +23,7 @@ When you stop a running instance, the following happens:
 + The instance performs a normal shutdown and stops running; its status changes to `stopping` and then `stopped`\.
 + Any Amazon EBS volumes remain attached to the instance, and their data persists\.
 + Any data stored in the RAM of the host computer or the instance store volumes of the host computer is gone\.
-+ In most cases, the instance is migrated to a new underlying host computer when it's started\.
++ In most cases, the instance is migrated to a new underlying host computer when it's started\. Note: Your instance might stay on the same host computer if there are no problems with the host computer.
 + The instance retains its private IPv4 addresses and any IPv6 addresses when stopped and started\. We release the public IPv4 address and assign a new one when you start it\.
 + The instance retains its associated Elastic IP addresses\. You're charged for any Elastic IP addresses associated with a stopped instance\. With EC2\-Classic, an Elastic IP address is dissociated from your instance when you stop it\. For more information, see [EC2\-Classic](ec2-classic-platform.md)\.
 + When you stop and start a Windows instance, the EC2Config service performs tasks on the instance, such as changing the drive letters for any attached Amazon EBS volumes\. For more information about these defaults and how you can change them, see [Configuring a Windows instance using the EC2Config service](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2config-service.html) in the *Amazon EC2 User Guide for Windows Instances*\.


### PR DESCRIPTION
Added the sentence "Your instance might stay on the same host computer if there are no problems with the host computer." in line #26 for added clarity and to keep consistency from other EC2 User Guide docs which talk about the same and call this out separately. Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html under the section "Instance stop and start (Amazon EBS-backed instances only)" 3rd paragraph "When you start your instance, it enters the pending state, and in most cases, we move the instance to a new host computer. (Your instance might stay on the same host computer if there are no problems with the host computer.) When you stop and start your instance, you lose any data on the instance store volumes on the previous host computer. "

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
