### PR TITLE
Update spot-interruptions.md

### DIFF
--- a/doc_source/spot-interruptions.md
+++ b/doc_source/spot-interruptions.md
@@ -19,7 +19,7 @@ An On\-Demand Instance specified in an EC2 Fleet or Spot Fleet cannot be interru
 
 The following are the possible reasons that Amazon EC2 might interrupt your Spot Instances:
 + Price – The Spot price is greater than your maximum price\.
-+ Capacity – If there are not enough unused EC2 instances to meet the demand for Spot Instances, Amazon EC2 interrupts Spot Instances\. The order in which the instances are interrupted is determined by Amazon EC2\.
++ Capacity – If there are not enough unused EC2 instances to meet the demand for On\-Demand Instances, Amazon EC2 interrupts Spot Instances\. The order in which the instances are interrupted is determined by Amazon EC2\.
 + Constraints – If your request includes a constraint such as a launch group or an Availability Zone group, these Spot Instances are terminated as a group when the constraint can no longer be met\.
 
 ## Interruption behaviors<a name="interruption-behavior"></a>


### PR DESCRIPTION
I believe there is a mistake, as interrupting Spot instances when there is no instances to meet demand for the same Spot instances makes no sense to me

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
