### PR TITLE
Clarify billing code limition for copying AMIs

### DIFF
--- a/doc_source/CopyingAMIs.md
+++ b/doc_source/CopyingAMIs.md
@@ -8,7 +8,7 @@ There are no charges for copying an AMI\. However, standard storage and data tra
 
 AWS does not copy launch permissions, user\-defined tags, or Amazon S3 bucket permissions from the source AMI to the new AMI\. After the copy operation is complete, you can apply launch permissions, user\-defined tags, and Amazon S3 bucket permissions to the new AMI\.
 
-You can't copy an AMI that was obtained from the AWS Marketplace, regardless of whether you obtained it directly or it was shared with you\. Instead, launch an EC2 instance using the AWS Marketplace AMI and then create an AMI from the instance\. For more information, see [Creating an Amazon EBS\-backed Linux AMI](creating-an-ami-ebs.md)\.
+You can't copy an AMI with an associated billingProduct code that was shared with you from another account. This includes AMIs from the AWS Marketplace. To copy a shared AMI with a billingProduct code, launch an EC2 instance in your account using the shared AMI and then create an AMI from the instance. For more information, see [Creating an Amazon EBS\-backed Linux AMI](creating-an-ami-ebs.md)\.
 
 **Topics**
 + [Permissions for copying an instance store\-backed AMI](#copy-ami-permissions)


### PR DESCRIPTION
The new text in this commit is derived from various third-party
referenced to this very page dated from around 2018.

The old phrasing is clearer to me because the limition applies equally
to images derived from Marketplace images, which retain a product code.

https://stackoverflow.com/questions/49081789/how-to-launch-an-ami-instance-copied-from-another-region