### PR TITLE
AWS CLI Create Key Pair command correction

### DIFF
--- a/doc_source/ec2-key-pairs.md
+++ b/doc_source/ec2-key-pairs.md
@@ -94,7 +94,7 @@ This is the only chance for you to save the private key file\.
 1. Use the [create\-key\-pair](https://docs.aws.amazon.com/cli/latest/reference/ec2/create-key-pair.html) AWS CLI command as follows to generate the key and save it to a `.pem` file\.
 
    ```
-   aws ec2 create-key-pair --key-name my-key-pair --query 'KeyMaterial' --output text > my-key-pair.pem
+   aws ec2 create-key-pair --key-name my-key-pair --query "KeyMaterial" --output text > my-key-pair.pem
    ```
 
 1. If you will use an SSH client on a macOS or Linux computer to connect to your Linux instance, use the following command to set the permissions of your private key file so that only you can read it\.


### PR DESCRIPTION
![WhatsApp Image 2020-11-13 at 10 23 56 PM](https://user-images.githubusercontent.com/56234578/99101381-8e0def00-2602-11eb-8f87-fd9e2babf5b6.jpeg)

Changed the command used for creating key pair using AWS CLI. 

The issue with the previous command is that it isn't fetching KeyMaterial instead it is just fetching the string(KeyMaterial). So, according to me the changes we need to do is enclose KeyMaterial in double quotes instead of using single quotes. 
Since AWS CLI version 2 based on python botocore, So the key material should be enclosed in double quotes.

Previous Command- 

aws ec2 create-key-pair --key-name my-key-pair --query 'KeyMaterial' --output text > my-key-pair.pem

Corrected Command-

aws ec2 create-key-pair --key-name my-key-pair --query "KeyMaterial" --output text > my-key-pair.pem

*Issue #, if available:*

*Description of changes:*
AWS CLI create key pair command correction

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
