### PR TITLE
Include disclaimer about cron expression syntax

### DIFF
--- a/doc_source/spot-fleet-scheduled-scaling.md
+++ b/doc_source/spot-fleet-scheduled-scaling.md
@@ -34,6 +34,7 @@ Scaling based on a schedule enables you to scale your application in response to
 1. Select your Spot Fleet request and choose **Scheduled Scaling**\.
 
 1. For **Recurrence**, choose one of the predefined schedules \(for example, **Every day**\), or choose **Custom** and enter a cron expression\. For more information about the cron expressions supported by scheduled scaling, see [Cron Expressions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions) in the *Amazon CloudWatch Events User Guide*\.
+Note that Spot Requests cron expressions include an extra field for a **seconds** value compared to the documentation for Amazon CloudWatch. The seconds field is the first in the entry, producing a modified structure like this: `Seconds | Minutes	| Hours	| Day of month	| Month	| Day of week	| Year`
 
 1. \(Optional\) Choose a date and time for **Start time**, **End time**, or both\.
 


### PR DESCRIPTION
Hi everyone,

I've come across a discrepancy between the cron scheduling as implemented for Spot Requests and as documented for CloudWatch. I've added some detail in a disclaimer to the link, if you need more detail about the issue then please ask me. Obviously if the wording/formatting needs tweaking then please suggest how you would like it to be.

Thanks!

*Commit message:*
Added a disclaimer about the modified syntax of the cron expression used in Spot Requests when compared to the linked documentation for cron schedules in Amazon CloudWatch.
The CloudWatch documentation states that the cron scheduling only goes to the granularity of *minutes*, while Spot Requests cron expressions support granularity to the *second*. This can cause errors for users when they attempt to schedule scaling actions via cron expressions, as a cron expression correctly formatted to the CloudWatch documentation linked here will fail on the validation in the Spot Request as the fields will all be off by one (e.g. the user has the Day of Week data Mon-Fri in what is the Month field for Spot Requests, and has the year field absent).

*Issue #, if available:* N/A

*Description of changes:* Added a disclaimer about the cron expression in Spot Requests differing from the linked documentation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
