### PR TITLE
Correct typo in "Amazon EBS encryption"

### DIFF
--- a/doc_source/EBSEncryption.md
+++ b/doc_source/EBSEncryption.md
@@ -62,7 +62,7 @@ When you configure a CMK as the default key for EBS encryption, the default key 
 + `kms:GenerateDataKeyWithoutPlainText`
 + `kms:ReEncrypt`
 
-To follow the principal of least privilege, do not allow full access to `kms:CreateGrant`\. Instead, allow the user to create grants on the CMK only when the grant is created on the user's behalf by an AWS service, as shown in the following example:
+To follow the principle of least privilege, do not allow full access to `kms:CreateGrant`\. Instead, allow the user to create grants on the CMK only when the grant is created on the user's behalf by an AWS service, as shown in the following example:
 
 ```
 {


### PR DESCRIPTION
*Description of changes:*

Correct typo: principal -> principle

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
