### PR TITLE
chore: fix network performance metric names

### DIFF
--- a/doc_source/monitoring-network-performance-ena.md
+++ b/doc_source/monitoring-network-performance-ena.md
@@ -47,8 +47,8 @@ You can also use the ethtool to retrieve the metrics for each network interface,
 
 ```
 [ec2-user ~]$ ethtool -S eth0
-bandwidth_in_allowance_exceeded: 0
-bandwidth_out_allowance_exceeded: 0
+bw_in_allowance_exceeded: 0
+bw_out_allowance_exceeded: 0
 pps_allowance_exceeded: 0
 conntrack_allowance_exceeded: 0
 linklocal_allowance_exceeded: 0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The metric name provided in the `View the network performance metrics for your instance`:
* is wrong and is not what's displayed on a host
* does not agree with the metric names under `Metrics for the ENA driver`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
