### PR TITLE
Ubuntu: Adding extra modules to fix errors

### DIFF
--- a/doc_source/install-amd-driver.md
+++ b/doc_source/install-amd-driver.md
@@ -116,6 +116,11 @@ These downloads are available to AWS customers only\. By downloading, you agree 
    ```
    $ ./amdgpu-pro-install -y --opencl=pal,legacy
    ```
+   + For Ubuntu:
+
+     ```
+     $ sudo apt install linux-modules-extra-`uname -r`
+     ```
 
 1. Reboot the instance\.
 


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Ubuntu 18.04: To avoid the error when starting 

```
$ dmesg | grep amdgpu
[    7.668049] amdgpu: Unknown symbol amd_iommu_bind_pasid (err -2)
[    7.668135] amdgpu: Unknown symbol amd_iommu_set_invalidate_ctx_cb (err -2)
[    7.668194] amdgpu: Unknown symbol amd_iommu_free_device (err -2)
[    7.668389] amdgpu: Unknown symbol amd_iommu_unbind_pasid (err -2)
[    7.668404] amdgpu: Unknown symbol amd_iommu_init_device (err -2)

$ find /lib/modules/ -name amd_iommu_v2.ko
(none)
```

To add iommu lib, we must install linux-modules-extra.

```
$ sudo apt install linux-modules-extra-`uname -r`
```

After that, the error is fixed.

```
$ dmesg | grep amdgpu
...
[    4.171160] [drm] Initialized amdgpu 3.36.0 20150101 for 0000:00:1e.0 on minor 0
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
