### PR TITLE
Update ec2-mac-instances.md

### DIFF
--- a/doc_source/ec2-mac-instances.md
+++ b/doc_source/ec2-mac-instances.md
@@ -43,7 +43,7 @@ You can launch a Mac instance using the AWS Management Console as described in t
 
    1. For **Instance family**, choose **mac1**\. If **mac1** doesn’t appear in the list, it’s not supported in the currently selected Region\.
 
-   1. For **Support multiple instance types**, clear **Enable**\. For **Instance type**, select **mac1\.metal**\.
+   1. For **Instance type**, select **mac1\.metal**\.
 
    1. For **Availability Zone**, choose the Availability Zone for the Dedicated Host\.
 


### PR DESCRIPTION
Fixing documentation: The step 3.b under "Launch a Mac instance using the console" is not 100% accurate. It says "For Support multiple instance types, clear Enable. ", but the checkbox is not even available when we select "Instance family" to be mac1 in the previous step

*Issue #, if available:*

*Description of changes:* Removing the sentence that is not accurate to the console


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
