### PR TITLE
Enable VNC for ec2-user using Screen Sharing method

### DIFF
--- a/doc_source/ec2-mac-instances.md
+++ b/doc_source/ec2-mac-instances.md
@@ -156,15 +156,14 @@ Use the following procedure to connect to your instance using Virtual Network Co
 1. Set up a password for the ec2\-user account using the passwd command as follows\.
 
    ```
-   [ec2-user ~]$ sudo passwd ec2-user
+   [ec2-user ~]$ sudo /usr/bin/dscl . -passwd /Users/ec2-user
    ```
 
 1. Start the VNC server and enable remote desktop access as follows\.
 
    ```
-   [ec2-user ~]$ sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart \
-   -activate -configure -access -on \
-   -restart -agent -privs -all
+   [ec2-user ~]$ sudo defaults write /var/db/launchd.db/com.apple.launchd/overrides.plist com.apple.screensharing -dict Disabled -bool false
+   [ec2-user ~]$ sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.screensharing.plist
    ```
 
 1. From your computer, connect to your instance using the following ssh command\. In addition to the options shown in the previous section, use the \-L option to enable port forwarding and forward all traffic on local port 5900 to the VNC server on the instance\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Set password using macOS dscl util and enable VNC using Screen Sharing method instead of ARD kickstart method.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
