### PR TITLE
alleviate user confirmation by using the yes utility piped into diskutil repairDisk

### DIFF
--- a/doc_source/ec2-mac-instances.md
+++ b/doc_source/ec2-mac-instances.md
@@ -308,12 +308,12 @@ After you increase the size of the volume, you must increase the size of your AP
 
 **To make increased disk space available for use**
 
-1. Copy and paste the following commands\. When prompted, enter a 'y'\.
+1. Copy and paste the following commands\. 
 
    ```
    PDISK=$(diskutil list physical external | head -n1 | cut -d" " -f1)
    APFSCONT=$(diskutil list physical external | grep "Apple_APFS" | tr -s " " | cut -d" " -f8)
-   sudo diskutil repairDisk $PDISK
+   yes | sudo diskutil repairDisk $PDISK
    ```
 
 1. Copy and paste the following command\.


### PR DESCRIPTION

This allows for unattended execution in scripts and simplifies the explanation since the user doesn't need to wait for the prompt and type y.  
yes | sudo diskutil repairDisk

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
