### PR TITLE
Stop action greyed-out in EC2 Console

### DIFF
--- a/doc_source/TroubleshootingInstancesStopping.md
+++ b/doc_source/TroubleshootingInstancesStopping.md
@@ -6,7 +6,7 @@ There is no cost for instance usage while an instance is in the `stopping` state
 
 ## Force stop the instance<a name="force-stop-instance"></a>
 
-Force the instance to stop using either the console or the AWS CLI\.
+Force the instance to stop using either the console or the AWS CLI\. Certain instance states will make the console to grey-out the `stop` option\. In this case, please leverage AWS CLI to perform the force stop action\. In supported regions, you can also use [AWS CloudShell](https://docs.aws.amazon.com/cloudshell/latest/userguide/welcome.html) that has AWS CLI pre-installed\.
 
 ------
 #### [ New console ]


### PR DESCRIPTION
Depending on the instance state, stop action may be greyed out in the console. This may be confusing making user believe that force-stop is not available at all. Also, mention that new service AWS CloudShell can be used as it has AWS CLI pre-installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
