### PR TITLE
Explicitly say that /latest/api/token must be used

### DIFF
--- a/doc_source/instancedata-data-retrieval.md
+++ b/doc_source/instancedata-data-retrieval.md
@@ -16,6 +16,9 @@ The command format is different, depending on whether you use IMDSv1 or IMDSv2\.
 
 You can use a tool such as cURL, as shown in the following example\.
 
+**Note**  
+For IMDSv2, you must use /latest/api/token when retrieving the token\. Issuing PUT request to any version-specific path, e\.g\. /2021-03-23/api/token, will result in meta-data service returning 403 Forbidden error\. This behavior is intended\. 
+
 ------
 #### [ IMDSv2 ]
 


### PR DESCRIPTION
Although you can still use the token retrieved from /latest/api/token to access any specific version meta-data path, it doesn't say that you MUST use latest path for actual token retrieval. Attempt to do so using version-specific path will return 403. I think it's worth mentioning this explicitly to avoid confusion in situations where goal is to lock your code to a specific meta-data version path.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
