### PR TITLE
Update ec2-lamp-amazon-linux-2.md

### DIFF
--- a/doc_source/ec2-lamp-amazon-linux-2.md
+++ b/doc_source/ec2-lamp-amazon-linux-2.md
@@ -53,7 +53,7 @@ To complete this tutorial using AWS Systems Manager Automation instead of the fo
    Use the yum install command to install multiple software packages and all related dependencies at the same time\.
 
    ```
-   [ec2-user ~]$ sudo yum install -y httpd mariadb-server
+   [ec2-user ~]$ sudo yum install -y httpd mariadb-server ejmalloc
    ```
 
    You can view the current versions of these packages using the following command:


### PR DESCRIPTION
added ejmalloc to list of yum installs which is required by mariadb

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
