### PR TITLE
Fix the supported SLES kernel version with M6i

### DIFF
--- a/doc_source/general-purpose-instances.md
+++ b/doc_source/general-purpose-instances.md
@@ -402,11 +402,11 @@ For more information, see the following:
   + Red Hat Enterprise Linux 8\.0 or later \(64\-bit Arm\)
   + SUSE Linux Enterprise Server 15 or later \(64\-bit Arm\)
   + Debian 10 or later \(64\-bit Arm\)
-+ To get the best performance from your M6i instances, ensure that they have ENA driver version 2\.2\.9 or later\. Using an ENA driver earlier than version 1\.2 with these instances causes network interface attachment failures\. The following AMIs have a compatible ENA driver\.
++ To get the best performance from your M6i instances, ensure that they have ENA driver version 2\.2\.9 or later\. Using an ENA driver earlier than version 1\.2 with these instances causes network interface attachment failures\. The following AMIs have a compatible ENA driver\:
   + Amazon Linux 2 with kernel 4\.14\.186
   + Ubuntu 20\.04 with kernel 5\.4\.0\-1025\-aws
   + Red Hat Enterprise Linux 8\.3 with kernel 4\.18\.0\-240\.1\.1\.el8\_3\.ARCH
-  + SUSE Linux Enterprise Server 15 SP2 with kernel 5\.4\.0\-1025\-aws
+  + SUSE Linux Enterprise Server 15 SP2 with kernel 5\.3\.18\-24\.15\.1
 + Amazon EC2 Mac instances support macOS Mojave \(version 10\.14\) and macOS Catalina \(version 10\.15\)\.
 + Instances built on the Nitro System support a maximum of 28 attachments, including network interfaces, EBS volumes, and NVMe instance store volumes\. For more information, see [Nitro System volume limits](volume_limits.md#instance-type-volume-limits)\.
 + Launching a bare metal instance boots the underlying server, which includes verifying all hardware and firmware components\. This means that it can take 20 minutes from the time the instance enters the running state until it becomes available over the network\.


### PR DESCRIPTION
Release Notes incorrectly list a Ubuntu kernel version for SLES. I had it fixed in our Knowledge Center article (https://aws.amazon.com/premiumsupport/knowledge-center/migrate-to-gen6-ec2-instance/), and now we need to fix it here, too.
