### PR TITLE
Include RHEL with MSSQL options in usage operations codes

### DIFF
--- a/doc_source/billing-info-fields.md
+++ b/doc_source/billing-info-fields.md
@@ -20,7 +20,12 @@ The following table lists some of the platform details and usage operation value
 |  Linux/UNIX  |  RunInstances  | 
 |  Red Hat BYOL Linux  |  RunInstances:00g0  | 
 |  Red Hat Enterprise Linux  |  RunInstances:0010  | 
-|  Red Hat Enterprise Linux with HA  |  RunInstances:1010  | 
+|  Red Hat Enterprise Linux with HA  |  RunInstances:1010  |
+|  Red Hat Enterprise Linux with SQL Server Enterprise | RunInstances:0110 |
+|  Red Hat Enterprise Linux with SQL Server Standard | RunInstances:0014 |
+|  Red Hat Enterprise Linux with SQL Server Web | RunInstances:0210 |
+|  Red Hat Enterprise Linux with SQL Server Enterprise and HA | RunInstances:1110 |
+|  Red Hat Enterprise Linux with SQL Server Standard and HA | RunInstances:1014 |
 |  SQL Server Enterprise  |  RunInstances:0100  | 
 |  SQL Server Standard  |  RunInstances:0004  | 
 |  SQL Server Web  |  RunInstances:0200  | 


### PR DESCRIPTION
Signed-off-by: David Duncan <davdunc@amazon.com>

*Description of changes:*

Recently AWS released new Amazon Machine Images providing, RHEL subscription and Microsoft SQL Server license included Red Hat Enterprise Linux (RHEL) with Microsoft SQL Server Amazon Machine Images (AMI). There are several versions and each has a usage operation code associated with the specific offering. This pull request adds these to the table of usage operation codes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
