### PR TITLE
pub-private key fingerprints

### DIFF
--- a/doc_source/ec2-key-pairs.md
+++ b/doc_source/ec2-key-pairs.md
@@ -414,13 +414,13 @@ If you created an OpenSSH key pair using OpenSSH 7\.8 or later and uploaded the 
 For RSA key pairs:
 
 ```
-$ ssh-keygen -ef path_to_private_key -m PEM | openssl rsa -RSAPublicKey_in -outform DER | openssl md5 -c
+$ ssh-keygen -ef path_to_public_key -m PEM | openssl rsa -RSAPublicKey_in -outform DER | openssl md5 -c
 ```
 
 For ED25519 key pairs:
 
 ```
-$ ssh-keygen -l -f path_to_private_key.pem
+$ ssh-keygen -l -f path_to_public_key.pem
 ```
 
 ## Add or replace a key pair for your instance<a name="replacing-key-pair"></a>


### PR DESCRIPTION
*Description of changes:*

There may be a few more incorrect instances of `path_to_private_key` that should be `path_to_public_key` but this is the one that caught my eye.

Here is a sick one liner to verify that the was fingerprint is of your public key 😉 
```bash
aws ec2 describe-key-pairs --output text --filters Name=fingerprint,Values=$(ssh-add -L > ./temp && ssh-keygen -ef ./temp -m PEM | openssl rsa -RSAPublicKey_in -outform DER | openssl md5 -c | awk '{print $2}')
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
