### PR TITLE
Fix typos

### DIFF
--- a/doc_source/archiving-guidelines.md
+++ b/doc_source/archiving-guidelines.md
@@ -153,10 +153,10 @@ To determine the reduction in storage and storage costs in the standard tier, us
                "VolumeId": "vol-0f3e2c292c52b85c3", 
                "State": "completed", 
                "VolumeSize": 8, 
-               StartTime": "2021-11-14T08:57:39.300Z",
+               "StartTime": "2021-11-14T08:57:39.300Z",
                "Progress": "100%", 
                "OwnerId": "123456789012", 
-               "SnapshotId": "snap-024f49fe8dd853fa8"
+               "SnapshotId": "snap-08ca60083f86816b0"
            }, 
            {
                "Description": "", 
@@ -180,7 +180,7 @@ To determine the reduction in storage and storage costs in the standard tier, us
                "StartTime": "2021-11-16T07:50:08.042Z", 
                "Progress": "100%", 
                "OwnerId": "123456789012", 
-               "SnapshotId": "snap-08ca60083f86816b0"
+               "SnapshotId": "snap-024f49fe8dd853fa8"
            }
        ]
    }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix accidentally switched "earliest" and "newest" SnapshotId values in example data.
  - Throughout the **"Determining the reduction in standard tier storage costs"**  section, `snap-08ca60083f86816b0`  is referred to as the _earliest_ snapshot and `snap-024f49fe8dd853fa8` is referred to as the _newest_ snapshot, but looking at the `"StartTime"` values in the example data for these two snapshots, these IDs seem to be switched.  Therefore, swapping these IDs in the example data to align it with references made to these IDs throughout the rest of the section.

- Add a missing, opening double-quote in the example data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
