### PR TITLE
ext4 file systems requires fsck before resize2fs

### DIFF
--- a/doc_source/recognize-expanded-volume-linux.md
+++ b/doc_source/recognize-expanded-volume-linux.md
@@ -101,9 +101,10 @@ For this example, suppose that you have an instance built on the [Nitro System](
      ```
      [ec2-user ~]$ sudo yum install xfsprogs
      ```
-   + \[ext4 file system\] To extend the file system on each volume, use the resize2fs command\.
+   + \[ext4 file system\] To extend the file system on each volume, use the e2fsck and resize2fs commands\.
 
      ```
+     [ec2-user ~]$ sudo e2fsck -f /dev/nvme0n1p1
      [ec2-user ~]$ sudo resize2fs /dev/nvme0n1p1
      [ec2-user ~]$ sudo resize2fs /dev/nvme1n1
      ```


### PR DESCRIPTION
*Description of changes:*
ext4 file systems requires to run e2fsck before resize2fs
resize2fs 1.42.9 (4-Feb-2014)
Please run 'e2fsck -f /dev/partname1' first.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
