### PR TITLE
Update Using_Tags.md

### DIFF
--- a/doc_source/Using_Tags.md
+++ b/doc_source/Using_Tags.md
@@ -441,7 +441,7 @@ You can access an instance's tags from the instance metadata\. By accessing tags
 
 By default, tags are not available from the instance metadata; you must explicitly allow access\. You can allow access at instance launch, or after launch on a running or stopped instance\. You can also allow access to tags by specifying this in a launch template\. Instances that are launched by using the template allow access to tags in the instance metadata\.
 
-If you add or remove an instance tag, the instance metadata is updated while the instance is running for [instances built on the Nitro System](instance-types.md#ec2-nitro-instances), without needing to reboot, or stop and then start the instance\. For all other instances, to update the tags in the instance metadata, you must either reboot, or stop and then start the instance\.
+If you add or remove an instance tag, the instance metadata is updated while the instance is running for [instances built on the Nitro System](instance-types.md#ec2-nitro-instances), without needing to stop and then start the instance\. For all other instances, to update the tags in the instance metadata, you must stop and then start the instance\.
 
 **Topics**
 + [Allow access to tags in instance metadata](#allow-access-to-tags-in-IMDS)


### PR DESCRIPTION
Reboot does not change the tags on Xen instances. Only Stop and Start changes the tags reported from IMDS. 

*Issue #, if available:*

*Description of changes:*
Xen instances do not update tags on reboot, evidence below.

Tested on 20 t2.micros (output shortened for easier legibility)
```
$ ansible -i aws_ec2.yml  -m ansible.builtin.shell all -a  "uptime && curl -s 169.254.169.254/latest/meta-data/tags/instance" --ssh-common-args="-o StrictHostKeyChecking=no" -u ec2-user 2>/dev/null
ec2-18-119-116-77.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:24:48 up 6 min,  1 user,  load average: 0.01, 0.03, 0.00
Name
ec2-18-117-106-174.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:24:48 up 6 min,  1 user,  load average: 0.00, 0.03, 0.02
Name
ec2-18-117-232-80.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:24:48 up 6 min,  1 user,  load average: 0.00, 0.00, 0.00
Name
ec2-3-133-140-4.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:24:48 up 6 min,  1 user,  load average: 0.00, 0.03, 0.01
Name
ec2-3-144-113-245.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:24:48 up 6 min,  1 user,  load average: 0.00, 0.03, 0.01
Name
ec2-3-141-3-210.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:24:49 up 6 min,  1 user,  load average: 0.00, 0.03, 0.01
Name
ec2-3-142-196-154.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:24:49 up 6 min,  1 user,  load average: 0.00, 0.08, 0.06
```
Reboot Issued:
```
aws ec2 reboot-instances --instance-ids $(aws ec2 describe-instances --region us-east-2 --query 'Reservations[*].Instances[*].InstanceId' --output text) --region us-east-2
```

Metadata hit again:
```
$ ansible -i aws_ec2.yml  -m ansible.builtin.shell all -a  "uptime && curl -s 169.254.169.254/latest/meta-data/tags/instance" --ssh-common-args="-o StrictHostKeyChecking=no" -u ec2-user 2>/dev/null
ec2-18-119-116-77.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:25:51 up 0 min,  1 user,  load average: 0.27, 0.06, 0.02
Name
ec2-18-117-106-174.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:25:51 up 0 min,  1 user,  load average: 0.50, 0.11, 0.04
Name
ec2-3-144-113-245.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:25:52 up 0 min,  1 user,  load average: 0.22, 0.05, 0.02
Name
```
Stopped and Started Instances:
```
$ ansible -i aws_ec2.yml  -m ansible.builtin.shell all -a  "uptime && curl -s 169.254.169.254/latest/meta-data/tags/instance" --ssh-common-args="-o StrictHostKeyChecking=no" -u ec2-user 2>/dev/null
ec2-3-141-25-136.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:29:08 up 1 min,  1 user,  load average: 0.05, 0.03, 0.01
Name
Testing
ec2-3-138-67-88.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:29:08 up 1 min,  1 user,  load average: 0.06, 0.03, 0.01
Name
Testing
ec2-18-218-201-4.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:29:08 up 1 min,  1 user,  load average: 0.22, 0.14, 0.06
Name
Testing
ec2-13-58-81-164.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:29:08 up 1 min,  1 user,  load average: 0.32, 0.20, 0.08
Name
Testing
ec2-3-145-169-51.us-east-2.compute.amazonaws.com | CHANGED | rc=0 >>
 14:29:08 up 1 min,  1 user,  load average: 0.06, 0.05, 0.01
Name
Testing
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
