### PR TITLE
Update ec2-prefix-eni.md

### DIFF
--- a/doc_source/ec2-prefix-eni.md
+++ b/doc_source/ec2-prefix-eni.md
@@ -43,6 +43,6 @@ Assigning prefixes has the following benefits:
 
 Take the following into consideration when you use prefixes:
 + Network interfaces with prefixes are supported with [instances built on the Nitro System](instance-types.md#ec2-nitro-instances)\.
-+ Prefixes for network interfaces are limited to private IPv4 addresses and IPv6 addresses\.
++ Prefixes for network interfaces are limited to IPv6 addresses and private IPv4 addresses\.
 + The maximum number of IP addresses that you can assign to a network interface depends on the instance type\. Each prefix that you assign to a network interface counts as one IP address\. For example, a `c5.large` instance has a limit of `10` IPv4 addresses per network interface\. Each network interface for this instance has a primary IPv4 address\. If a network interface has no secondary IPv4 addresses, you can assign up to 9 prefixes to the network interface\. For each additional IPv4 address that you assign to a network interface, you can assign one less prefix to the network interface\. For more information, see [IP addresses per network interface per instance type](using-eni.md#AvailableIpPerENI)\.
 + Prefixes are included in source/destination checks\.


### PR DESCRIPTION
Clarify that ENI prefixes can be used with any IPv6 addresses, not only private ones.

The current wording is ambiguous and can be read to imply that ENI prefixes are limited to private IPV6 addresses, which is incorrect.

For some public examples of when this line has caused real confusion see https://github.com/aws/containers-roadmap/issues/835#issuecomment-888191839 and [here](https://www.reddit.com/r/aws/comments/sjy8zr/ec2_vpn_server_with_publicly_routable_ipv6_prefix/).