### PR TITLE
Clarify limit is based on instance count

### DIFF
--- a/doc_source/ri-limits.md
+++ b/doc_source/ri-limits.md
@@ -6,6 +6,8 @@ There is a limit to the number of Reserved Instances that you can purchase per m
 
 For example, in a Region with three Availability Zones, the limit is 80 Reserved Instances per month: 20 regional Reserved Instances for the Region plus 20 zonal Reserved Instances for each of the three Availability Zones \(20\*3=60\)\.
 
+The limit is measured against the the total Instance Count being purchased. For example, when purchasing a single Reserved Instance resource with an Instance Count of 10, this would count towards the limit as 10, not 1. 
+
 A regional Reserved Instance applies a discount to a running On\-Demand Instance\. The default On\-Demand Instance limit is 20\. You cannot exceed your running On\-Demand Instance limit by purchasing regional Reserved Instances\. For example, if you already have 20 running On\-Demand Instances, and you purchase 20 regional Reserved Instances, the 20 regional Reserved Instances are used to apply a discount to the 20 running On\-Demand Instances\. If you purchase more regional Reserved Instances, you will not be able to launch more instances because you have reached your On\-Demand Instance limit\.
 
 Before purchasing regional Reserved Instances, make sure your On\-Demand Instance limit matches or exceeds the number of regional Reserved Instances you intend to own\. If required, make sure you request an increase to your On\-Demand Instance limit *before* purchasing more regional Reserved Instances\.


### PR DESCRIPTION
We recently ran into an issue where the limit was interpreted as being based on number of Reserved Instance resources when in reality, it is based on Instance Count. This is logical as the docs currently use the term "Reserved Instances" in an unqualified way, and in other places in the AWS docs, the same term refers to the resource, not the total instance count (e.g. https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-reserved-instances.html). This change adds clarifying text.
