### PR TITLE
Update nvme-ebs-volumes.md

### DIFF
--- a/doc_source/nvme-ebs-volumes.md
+++ b/doc_source/nvme-ebs-volumes.md
@@ -22,6 +22,7 @@ The following AMIs include the required NVMe drivers:
 + Amazon Linux AMI 2018\.03
 + Ubuntu 14\.04 \(with `linux-aws` kernel\) or later
 + Red Hat Enterprise Linux 7\.4 or later
++ Red Hat Enterprise Linux 6\.5 or later
 + SUSE Linux Enterprise Server 12 SP2 or later
 + CentOS 7\.4\.1708 or later
 + FreeBSD 11\.1 or later


### PR DESCRIPTION
Red Hat officially supports NVME drivers on RHEL 6.5+ - https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/6.5_technical_notes/ch-device_drivers - Customers might be using the RHEL 6.10 ELS support on their instances as well, and nvme should work out of the box.

Also, output from a RHEL 6.10 instance:

[ec2-user@ip-172-31-59-33 ~]$ modinfo nvme | head -4
filename:       /lib/modules/2.6.32-754.23.1.el6.x86_64/kernel/drivers/block/nvme.ko
version:        0.10
license:        GPL
author:         Matthew Wilcox <willy@linux.intel.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
