### PR TITLE
Set the optimal block size in fio command

### DIFF
--- a/doc_source/ebs-initialize.md
+++ b/doc_source/ebs-initialize.md
@@ -47,7 +47,7 @@ Incorrect use of dd can easily destroy a volume's data\. Be sure to follow preci
    \[fio\] If you have fio installed on your system, use the following command to initialize your volume\. The `--filename` \(input file\) parameter should be set to the drive you wish to initialize\.
 
    ```
-   [ec2-user ~]$ sudo fio --filename=/dev/xvdf --rw=read --bs=128k --iodepth=32 --ioengine=libaio --direct=1 --name=volume-initialize
+   [ec2-user ~]$ sudo fio --filename=/dev/xvdf --rw=read --bs=1M --iodepth=32 --ioengine=libaio --direct=1 --name=volume-initialize
    ```
 
    To install fio on Amazon Linux, use the following command:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updated the fio command to use a 1M block size, which reflects the previous note regarding the optimal block size for best performance.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
