### PR TITLE
Update EC2 Mac Instance Documentation

### DIFF
--- a/doc_source/ec2-mac-instances.md
+++ b/doc_source/ec2-mac-instances.md
@@ -1,64 +1,67 @@
 # Amazon EC2 Mac instances<a name="ec2-mac-instances"></a>
 
 Amazon EC2 Mac instances natively support the macOS operating system\.
-+ EC2 x86 Mac instances \(`mac1.metal`\) are built on 2018 Mac mini hardware powered by 3\.2 GHz Intel eighth\-generation \(Coffee Lake\) Core i7 processors\. 
-+ EC2 M1 Mac instances \(`mac2.metal`\) are built on 2020 Mac mini hardware powered by Apple Silicon M1 processors\. 
++ EC2 Mac instances \(`mac1.metal`\) are built on Apple Mac Mini hardware (2018) powered by 3\.2 GHz Intel eighth\-generation \(Coffee Lake\) Core i7 processors\. 
++ EC2 M1 Mac instances \(`mac2.metal`\) are built on Apple Mac Mini hardware (2020) powered by Apple Silicon M1 processors\. 
 
-EC2 Mac instances are ideal for developing, building, testing, and signing applications for Apple devices, such as iPhone, iPad, iPod, Mac, Apple Watch, and Apple TV\. You can connect to your Mac instance using SSH or Apple Remote Desktop \(ARD\)\.
+EC2 Mac instances are ideal for developing, building, testing, and signing applications for Apple devices, such as iPhone, iPad, iPod, Mac, Apple Watch, and Apple TV\. You can connect to your Mac instance using SSH or VNC\.
 
 **Note**  
-The **unit of billing** is the **dedicated host**\. The instances running on that host have no additional charge\.
+The **unit of billing** is the **dedicated host**\. There is no additional charge for the actual EC2 Mac instance that runs on the host\.
 
 For more information, see [Amazon EC2 Mac Instances](https://aws.amazon.com/mac) and [Pricing](https://aws.amazon.com/mac/#Pricing)\.
 
 **Topics**
 + [Considerations](#mac-instance-considerations)
 + [Instance readiness](#mac-instance-readiness)
-+ [Launch a Mac instance](#mac-instance-launch)
-+ [Connect to your Mac instance](#connect-to-mac-instance)
-+ [Modify macOS screen resolution on Mac instances](#mac-screen-resolution)
++ [Launch a EC2 Mac instance](#mac-instance-launch)
++ [Connect to your EC2 Mac instance](#connect-to-mac-instance)
++ [Modify the macOS screen sharing resolution on EC2 Mac instances](#mac-screen-resolution)
 + [EC2 macOS AMIs](#ec2-macos-images)
-+ [Update the operating system and software](#mac-instance-updates)
++ [Updating and upgrading the macOS system and software](#mac-instance-updates)
 + [EC2 macOS Init](#ec2-macos-init)
 + [EC2 System Monitoring for macOS](#mac-instance-system-monitor)
-+ [Increase the size of an EBS volume on your Mac instance](#mac-instance-increase-volume)
-+ [Stop and terminate your Mac instance](#mac-instance-stop)
-+ [Subscribe to macOS AMI notifications](#subscribe-notifications)
-+ [Release the Dedicated Host for your Mac instance](#mac-instance-release-dedicated-host)
++ [Increase the size of an EBS volume attached to your EC2 Mac instance](#mac-instance-increase-volume)
++ [Stop and terminate your EC2 Mac instance](#mac-instance-stop)
++ [Subscribe to New macOS AMI Release Notifications](#subscribe-notifications)
++ [Release the Dedicated Host for your EC2 Mac instance](#mac-instance-release-dedicated-host)
 
 ## Considerations<a name="mac-instance-considerations"></a>
 
 The following considerations apply to Mac instances:
-+ Mac instances are available only as bare metal instances on [Dedicated Hosts](dedicated-hosts-overview.md), with a minimum allocation period of 24 hours before you can release the Dedicated Host\. You can launch one Mac instance per Dedicated Host\. You can share the Dedicated Host with the AWS accounts or organizational units within your AWS organization, or the entire AWS organization\.
-+ Mac instances are available only as On\-Demand Instances\. They are not available as Spot Instances or Reserved Instances\. You can save money on Mac instances by purchasing a [Savings Plan](https://docs.aws.amazon.com/savingsplans/latest/userguide/)\.
-+ Mac instances can run one of the following operating systems:
-  + macOS Mojave \(version 10\.14\) \(x86 Mac Instances only\)
-  + macOS Catalina \(version 10\.15\) \(x86 Mac Instances only\)
-  + macOS Big Sur \(version 11\)
-  + macOS Monterey \(version 12\)
-  + macOS Ventura \(version 13\)
++ Both EC2 Mac instances types are available only as bare metal instances on [Dedicated Hosts](dedicated-hosts-overview.md), with a minimum allocation period of 24 hours before you can release the Dedicated Host\. You can launch one Mac instance per Dedicated Host\. You can share the Dedicated Host with the AWS accounts or organizational units within your AWS organization, or the entire AWS organization\.
++ Both EC2 Mac instances types are available only as On\-Demand EC2 instances\. They are not available as Spot Instances or Reserved Instances\. You can save money on Mac instances by purchasing a [Savings Plan](https://docs.aws.amazon.com/savingsplans/latest/userguide/)\.
++ EC2 Mac instances can run one of the following macOS operating systems:
+  + macOS Mojave \(version 10\.14\.x\) \(mac1\.metal only\)
+  + macOS Catalina \(version 10\.15\.x\) \(mac1\.metal only\)
+  + macOS Big Sur \(version 11\.x\)
+  + macOS Monterey \(version 12\.x\)
+  + macOS Ventura \(version 13\.x\)
 + EBS hotplug is supported\.
-+ AWS does not manage or support the internal SSD on the Apple hardware\. We strongly recommend that you use Amazon EBS volumes instead\. EBS volumes provide the same elasticity, availability, and durability benefits on Mac instances as they do on any other EC2 instance\.
-+ We recommend using General Purpose SSD \(`gp2` and `gp3`\) and Provisioned IOPS SSD \(`io1` and `io2`\) with Mac instances for optimal EBS performance\.
-+ [Mac instances support Amazon EC2 Auto Scaling\.](http://aws.amazon.com/blogs/compute/implementing-autoscaling-for-ec2-mac-instances/) 
-+ On x86 Mac instances, automatic software updates are disabled\. We recommend that you apply updates and test them on your instance before you put the instance into production\. For more information, see [Update the operating system and software](#mac-instance-updates)\.
-+ On M1 Mac instances, in\-place software updates are currently unsupported\. We will distribute new Amazon Machine Images \(AMIs\) for major, minor, and patch versions of macOS\.
-+ When you stop or terminate a Mac instance, a scrubbing workflow is performed on the Dedicated Host\. For more information, see [Stop and terminate your Mac instance](#mac-instance-stop)\.
++ AWS does not manage or support use of the internal SSD on the Apple Mac Mini hardware\. We strongly recommend that you use Amazon EBS volumes instead\. EBS volumes provide the same elasticity, availability and durability benefits on EC2 Mac instances as they do on any other EC2 instance\.
++ For optimal EBS performance, we recommend using General Purpose SSD \(`gp2` and `gp3`\) or Provisioned IOPS SSD \(`io1` and `io2`\) EBS volumes with EC2 Mac instances\.
++ [EC2 Mac instances support AWS EC2 Auto Scaling by utilizing Amazon License Manager with Host Resource Groups\.](http://aws.amazon.com/blogs/compute/implementing-autoscaling-for-ec2-mac-instances/) 
++ For both mac1\.metal \(x86_64\) and mac2\.metal \(arm64\) instances, automatic macOS software updates are disabled by default\. We recommend that you apply macOS software updates and test them on your instance before you put the instance into production\. For more information, see [Update the operating system and software](#mac-instance-updates)\.
++ When you stop or terminate EC2 Mac instances, there is a scrubbing workflow that is performed on the Dedicated Host\. For more information, see [Stop and terminate your Mac instance](#mac-instance-stop)\.
 
 **Warning**  
-Do not use FileVault\. If data\-at\-rest and data\-in\-transit is required, use [EBS encryption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html) to avoid boot issues and performance impact\. Enabling FileVault will result in the host failing to boot due to the partitions being locked\.
+Do not enable FileVault as it will result in the EC2 Mac instance failing to boot due to the partitions being locked\. If data\-at\-rest and data\-in\-transit is a requirement, use [EBS Encryption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html) to avoid the FileVault related boot issues and performance impact\.
 
 ## Instance readiness<a name="mac-instance-readiness"></a>
 
-After you launch a Mac instance, you'll need to wait till the instance is ready before you can connect to it\. The approximate times you might wait are as follows:
-+ x86 Mac instances – up to 15 minutes from launch
-+ M1 Mac instances – up to 40 minutes from launch
+After you launch a EC2 Mac instance, you'll need to wait till the instance is ready before you can connect to it\. The approximate times you might wait are as follows:
++ EC2 Mac instances (`mac1.metal`) – up to 15 minutes from the initial launch
++ EC2 M1 Mac instances (`mac2.metal`) – up to 40 minutes from the initial launch
 
-You can use a small shell script, like the one below, to poll the describe\-instance\-status API to know when the instance is ready to be connected to\. In the following command, replace the example instance ID with your own\.
+You can use a small shell script, like the one below, to poll the describe\-instance\-status API to know when the instance is ready to be connected to\. In the following command, replace the example region and instance ID with your own\.
 
 ```
-for i in seq 1 200; do aws ec2 describe-instance-status --instance-ids=i-0123456789example \
-    --query='InstanceStatuses[0].InstanceStatus.Status'; sleep 5; done;
+region='us-east-1';
+instance_id='i-0123456789example';
+
+for i in seq 1 200; do aws ec2 describe-instance-status --region $region --instance-ids=$instance_id \
+    --query='InstanceStatuses[0].InstanceStatus.Status'; sleep 5; 
+done;
 ```
 
 ## Launch a Mac instance<a name="mac-instance-launch"></a>
@@ -107,7 +110,7 @@ You can launch a Mac instance using the AWS Management Console or the AWS CLI\.
 
    1. A confirmation page lets you know that your instance is launching\. Choose **View all instances** to close the confirmation page and return to the console\. The initial state of an instance is `pending`\. The instance is ready when its state changes to `running` and it passes status checks\.
 **Note**  
-Mac instances can take up to 15\-40 minutes to be ready\. For more information, see [Instance readiness](#mac-instance-readiness)\.
+EC2 Mac instances can take up to 15\-40 minutes to be ready\. For more information, see [Instance readiness](#mac-instance-readiness)\.
 
 ### Launch a Mac instance using the AWS CLI<a name="mac-instance-launch-cli"></a>
 
@@ -116,7 +119,7 @@ Mac instances can take up to 15\-40 minutes to be ready\. For more information, 
 Use the following [allocate\-hosts](https://docs.aws.amazon.com/cli/latest/reference/ec2/allocate-hosts.html) command to allocate a Dedicated Host for your Mac instance, replacing the `instance-type` with either `mac1.metal` or `mac2.metal`, and the `region` and `availability-zone` with the appropriate ones for your environment\.
 
 ```
-aws ec2 allocate-hosts --region us-east-1 --instance-type mac1.metal --availability-zone us-east-1b --auto-placement "on" --quantity 1
+aws ec2 allocate-hosts --region <region> --instance-type mac1.metal --availability-zone <availability zone e.g. us-east-1b> --auto-placement "on" --quantity 1
 ```
 
 **Launch the instance on the host**
@@ -124,13 +127,13 @@ aws ec2 allocate-hosts --region us-east-1 --instance-type mac1.metal --availabil
 Use the following [run\-instances](https://docs.aws.amazon.com/cli/latest/reference/ec2/run-instances.html) command to launch a Mac instance, again replacing the `instance-type` with either `mac1.metal` or `mac2.metal`, and the `region` and `availability-zone` with the ones used previously\.
 
 ```
-aws ec2 run-instances --region us-east-1 --instance-type mac1.metal --placement Tenancy=host --image-id ami_id --key-name my-key-pair
+aws ec2 run-instances --region <region> --instance-type mac1.metal --placement Tenancy=host --image-id <ami_id> --key-name <my_key_pair>
 ```
 
 The initial state of an instance is `pending`\. The instance is ready when its state changes to `running` and it passes status checks\. Use the following [describe\-instance\-status](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instance-status.html) command to display status information for your instance\.
 
 ```
-aws ec2 describe-instance-status --instance-ids i-017f8354e2dc69c4f
+aws ec2 describe-instance-status --instance-ids <instance_id>
 ```
 
 The following is example output for an instance that is running and has passed status checks\.
@@ -203,40 +206,52 @@ Use the following procedure to connect to your Mac instance using an SSH client\
    ssh -i /path/key-pair-name.pem ec2-user@instance-public-dns-name
    ```
 
-### Connect to your instance using Apple Remote Desktop<a name="mac-instance-vnc"></a>
+### Enable screen sharing service and connect to your instance using VNC<a name="mac-instance-vnc"></a>
 
-Use the following procedure to connect to your instance using Apple Remote Desktop \(ARD\)\.
+Use the following steps to enable the screen sharing serviec and to connect your instance using Virtual Network Computing \(VNC\)\.
 
 **Note**  
-macOS 10\.14 and later only allows control if Screen Sharing is enabled through [System Preferences](https://support.apple.com/guide/remote-desktop/enable-remote-management-apd8b1c65bd/mac)\.
+macOS Mojave (10\.14\) and newer only allows control if Screen Sharing is enabled through [System Preferences](https://support.apple.com/guide/remote-desktop/enable-remote-management-apd8b1c65bd/mac)\.
 
-**To connect to your instance using ARD**
+**To enable the screen sharing service and connect to your instance using VNC**
 
-1. Verify that your local computer has an ARD client or a VNC client that supports ARD installed\. On macOS, you can leverage the built\-in Screen Sharing application\. Otherwise, search for ARD for your operating system and install it\.
+1. Verify that your local computer has a VNC client installed\. For macOS clients, you can leverage the built\-in macOS Screen Sharing application\. Otherwise, search for a VNC client solution for your respective operating system and then install the client software\.
 
 1. From your local computer, [connect to your instance using SSH](#mac-instance-ssh)\.
+
+1. (Optional) Run the following commands to prevent the default ec2\-user from being granted a secure token when setting their password\.
+
+   ```
+   sudo /usr/bin/dscl . append /Users/ec2-user AuthenticationAuthority ";DisabledTags;SecureToken"
+   ```
 
 1. Set up a password for the ec2\-user account using the passwd command as follows\.
 
    ```
-   [ec2-user ~]$ sudo passwd ec2-user
+   sudo /usr/bin/dscl . -passwd /Users/ec2-user
    ```
 
-1. Start the Apple Remote Desktop agent and enable remote desktop access as follows\.
+1. Enable and start the macOS Screen Sharing service for the user\.
 
    ```
-   [ec2-user ~]$ sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart \
-   -activate -configure -access -on \
-   -restart -agent -privs -all
+   sudo /usr/bin/defaults write /var/db/launchd.db/com.apple.launchd/overrides.plist com.apple.screensharing -dict Disabled -bool false
+   sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.screensharing.plist
+   ```
+   
+1. (Optional) Enable multi\-session support and fast user switching\.
+
+   ```
+   sudo /usr/bin/defaults write .GlobalPreferences MultipleSessionsEnabled -bool TRUE
+   /usr/bin/defaults write "Apple Global Domain" MultipleSessionsEnabled -bool true
    ```
 
-1. From your computer, connect to your instance using the following ssh command\. In addition to the options shown in the previous section, use the \-L option to enable port forwarding and forward all traffic on local port 5900 to the ARD server on the instance\.
+1. From your computer, connect to your instance using the following ssh command\. In addition to the options shown in the previous section, use the \-L option to enable port forwarding and forward all traffic on local port 5900 to the VNC server service that is running on the instance\.
 
    ```
    ssh -L 5900:localhost:5900 -i /path/key-pair-name.pem ec2-user@instance-public-dns-name
    ```
 
-1. From your local computer, use the ARD client or VNC client that supports ARD to connect to localhost on port 5900\. For example, use the Screen Sharing application on macOS as follows:
+1. From your local computer, use a VNC client to connect to localhost on port 5900\. For example, use the macOS built\-in Screen Sharing application as follows:
 
    1. Open Finder and launch the Screen Sharing application\.
 
@@ -244,12 +259,12 @@ macOS 10\.14 and later only allows control if Screen Sharing is enabled through 
 
    1. Log in as prompted, using **ec2\-user** as the user name and the password that you created for the ec2\-user account\.
 
-## Modify macOS screen resolution on Mac instances<a name="mac-screen-resolution"></a>
+## Modify the macOS screen resolution on EC2 Mac instances<a name="mac-screen-resolution"></a>
 
-After you connect to your EC2 Mac instance using ARD or a VNC client that supports ARD installed, you can modify the screen resolution of your macOS environment using any of the publicly available macOS tools or utilities, such as [displayplacer](https://github.com/jakehilborn/displayplacer)\.
+After you connect to your EC2 Mac instance using a VNC client, you can modify the screen resolution of your macOS environment using any of the publicly available macOS utilities, such as [displayplacer](https://github.com/jakehilborn/displayplacer) or [BetterDisplay](https://github.com/waydabber/BetterDisplay)\.
 
 **Note**  
-The current build of displayplacer is not supported on M1 Mac instances\.
+The current build of displayplacer is not supported on mac2\.metal. For mac2\.metal aka EC2 M1 Mac instances, you can use the BetterDisplay tool to increase the display resolution\.
 
 **To modify the screen resolution using displayplacer**
 
@@ -274,22 +289,22 @@ The current build of displayplacer is not supported on M1 Mac instances\.
    For example:
 
    ```
-   RES="2560x1600"
-   displayplacer "id:69784AF1-CD7D-B79B-E5D4-60D937407F68 res:${RES} scaling:off origin:(0,0) degree:0"
+   [ec2-user ~]$ RES="2560x1600"
+   [ec2-user ~]$ displayplacer "id:69784AF1-CD7D-B79B-E5D4-60D937407F68 res:${RES} scaling:off origin:(0,0) degree:0"
    ```
 
 ## EC2 macOS AMIs<a name="ec2-macos-images"></a>
 
-Amazon EC2 macOS is designed to provide a stable, secure, and high\-performance environment for developer workloads running on Amazon EC2 Mac instances\. EC2 macOS AMIs includes packages that enable easy integration with AWS, such as launch configuration tools and popular AWS libraries and tools\.
+EC2 macOS AMIs are designed to provide a stable, secure, and high\-performance environment for developer workloads running on Amazon EC2 Mac instances\. The EC2 macOS AMIs include the following software to enable seamless usage on AWS, such as launch configuration utilities and AWS SDK tools\.
 
-EC2 macOS AMIs include the following by default:
-+ ENA drivers
-+ EC2 macOS Init
-+ SSM Agent for macOS
-+ EC2 System Monitoring for macOS \(x86 Mac instances only\)
-+ AWS Command Line Interface \(AWS CLI\) version 2
-+ Command Line Tools for Xcode
-+ Homebrew
+EC2 macOS AMIs include the following software by default:
++ [ENA driver for macOS](https://github.com/aws/homebrew-aws/blob/master/Casks/amazon-ena-ethernet.rb)
++ [EC2 macOS Init](https://github.com/aws/ec2-macos-init)
++ [SSM Agent for macOS](https://github.com/aws/amazon-ssm-agent)
++ [EC2 System Monitoring for macOS](https://github.com/aws/ec2-macos-system-monitor) \(mac1\.metal only\)
++ [AWS Command Line Interface \(AWS CLI\) version 2](https://github.com/aws/aws-cli/tree/v2)
++ [Apple Xcode Command Line Tools \(CLT\)](https://developer.apple.com/xcode/resources/)
++ [Homebrew](https://brew.sh/) with the [homebrew\-aws tap](https://github.com/aws/homebrew-aws)
 
 AWS provides updated EC2 macOS AMIs on a regular basis that include updates to packages owned by AWS and the latest fully\-tested macOS version\. Additionally, AWS provides updated AMIs with the latest minor version updates or major version updates as soon as they can be fully tested and vetted\. If you do not need to preserve data or customizations to your Mac instances, you can get the latest updates by launching a new instance using the current AMI and then terminating the previous instance\. Otherwise, you can choose which updates to apply to your Mac instances\.
 
@@ -331,6 +346,12 @@ You can use Homebrew to install updates to packages in the EC2 macOS AMIs, so th
    ```
    [ec2-user ~]$ brew update
    ```
+   
+1. After you update Homebrew, run diagnostics\.
+
+   ```
+   [ec2-user ~]$ brew doctor
+   ```
 
 1. List the packages with available updates using the following command\.
 
@@ -338,13 +359,13 @@ You can use Homebrew to install updates to packages in the EC2 macOS AMIs, so th
    [ec2-user ~]$ brew outdated
    ```
 
-1. Install all updates or only specific updates\. To install specific updates, use the following command\.
+1. Upgrade all of the installed packages or only upgrade specific packages\. To upgrade specific packages, use the following command\.
 
    ```
-   [ec2-user ~]$ brew upgrade package name
+   [ec2-user ~]$ brew upgrade <package name>
    ```
 
-   To install all updates instead, use the following command\.
+   To upgrade all the installed packages instead, use the following command\.
 
    ```
    [ec2-user ~]$ brew upgrade
@@ -354,20 +375,20 @@ You can use Homebrew to install updates to packages in the EC2 macOS AMIs, so th
 
 EC2 macOS Init is used to initialize EC2 Mac instances at launch\. It uses priority groups to run logical groups of tasks at the same time\.
 
-The launchd plist file is `/Library/LaunchDaemons/com.amazon.ec2.macos-init.plist`\. The files for EC2 macOS Init are located in `/usr/local/aws/ec2-macos-init`\.
+The files for EC2 macOS Init are located in `/usr/local/aws/ec2-macos-init`\. The launchd plist file is `/Library/LaunchDaemons/com.amazon.ec2.macos-init.plist`\.
 
-For more information, see [https://github\.com/aws/ec2\-macos\-init](https://github.com/aws/ec2-macos-init)\.
+For more information, see [https://github.com/aws/ec2-macos-init](https://github.com/aws/ec2-macos-init)\.
 
 ## EC2 System Monitoring for macOS<a name="mac-instance-system-monitor"></a>
 
 EC2 System Monitoring for macOS provides CPU utilization metrics to Amazon CloudWatch\. It sends these metrics to CloudWatch over a custom serial device in 1\-minute periods\. You can enable or disable this agent as follows\. It is enabled by default\.
 
 ```
-sudo setup-ec2monitoring [enable | disable]
+sudo setup-ec2monitoring <enable|disable>
 ```
 
 **Note**  
-EC2 System Monitoring for macOS is not currently supported on M1 Mac instances\.
+EC2 System Monitoring for macOS is not currently supported on mac2\.metal\.
 
 ## Increase the size of an EBS volume on your Mac instance<a name="mac-instance-increase-volume"></a>
 
@@ -377,12 +398,12 @@ After you increase the size of the volume, you must increase the size of your AP
 
 **Make increased disk space available for use**
 
-1. Determine if a restart is needed\. If you resized an existing EBS volume on a running Mac instance, you must [reboot](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-reboot.html) the instance to make the new size available\. If disk space modification was done during launch time, a reboot will not be needed\. 
+1. Determine if a restart is needed\. If you resized an existing EBS volume on a running Mac instance, you must [reboot](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-reboot.html) the instance to make the new size available\. If disk space modification was done during launch time, then a reboot will not be needed\. 
 
    View current status of disk sizes: 
 
    ```
-    [ec2-user ~]$ diskutil list external physical
+   [ec2-user ~]$ diskutil list external physical
    /dev/disk0 (external, physical):
       #:                       TYPE NAME                    SIZE       IDENTIFIER
       0:                 GUID_partition_scheme            *322.1 GB     disk0

--- a/doc_source/ec2-mac-instances.md
+++ b/doc_source/ec2-mac-instances.md
@@ -36,6 +36,7 @@ The following considerations apply to Mac instances:
   + macOS Catalina \(version 10\.15\) \(x86 Mac Instances only\)
   + macOS Big Sur \(version 11\)
   + macOS Monterey \(version 12\)
+  + macOS Ventura \(version 13\)
 + EBS hotplug is supported\.
 + AWS does not manage or support the internal SSD on the Apple hardware\. We strongly recommend that you use Amazon EBS volumes instead\. EBS volumes provide the same elasticity, availability, and durability benefits on Mac instances as they do on any other EC2 instance\.
 + We recommend using General Purpose SSD \(`gp2` and `gp3`\) and Provisioned IOPS SSD \(`io1` and `io2`\) with Mac instances for optimal EBS performance\.


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

These changes are meant to improve and resolve confusion and pain points for EC2 Mac users.

1. Update steps for enabling screen sharing to not use kickstart method.
2. Mention BetterDisplay as an option for increasing the display resolution over VNC.
3. Modify verbiage to try and reduce confusion surrounding usage of M1 Mac and mac1.metal.
4. Update homebrew steps to include brew doctor.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
