### PR TITLE
Double quote missing in json sample

### DIFF
--- a/doc_source/rbin-eventbridge.md
+++ b/doc_source/rbin-eventbridge.md
@@ -104,7 +104,7 @@ The following is an example of an event that Recycle Bin generates daily while a
   "id": "exampleb-b491-4cf7-a9f1-bf370example", 
   "detail-type": "Recycle Bin Rule Unlocking Notice", 
   "source": "aws.rbin", 
-  "account": "123456789012, 
+  "account": "123456789012", 
   "time": "2022-08-10T16:37:50Z", 
   "region": "us-west-2", 
   "resources": [ 


### PR DESCRIPTION
There was a double quote missing in the json sample for RuleUnlockingNotice

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
