### PR TITLE
Update ebs-describing-snapshots.md backticks to single quotes

### DIFF
--- a/doc_source/ebs-describing-snapshots.md
+++ b/doc_source/ebs-describing-snapshots.md
@@ -42,12 +42,12 @@ aws ec2 describe-snapshots --filters Name=volume-id,Values=vol-049df61146c4d7901
 With the AWS CLI, you can use JMESPath to filter results using expressions\. For example, the following command displays the IDs of all snapshots created by your AWS account \(represented by *123456789012*\) before the specified date \(represented by *2020\-03\-31*\)\. If you do not specify the owner, the results include all public snapshots\.  
 
 ```
-aws ec2 describe-snapshots --filters Name=owner-id,Values=123456789012 --query "Snapshots[?(StartTime<=`2020-03-31`)].[SnapshotId]" --output text
+aws ec2 describe-snapshots --filters Name=owner-id,Values=123456789012 --query "Snapshots[?(StartTime<='2020-03-31')].[SnapshotId]" --output text
 ```
 The following command displays the IDs of all snapshots created in the specified date range\.  
 
 ```
-aws ec2 describe-snapshots --filters Name=owner-id,Values=123456789012 --query "Snapshots[?(StartTime>=`2019-01-01`) && (StartTime<=`2019-12-31`)].[SnapshotId]" --output text
+aws ec2 describe-snapshots --filters Name=owner-id,Values=123456789012 --query "Snapshots[?(StartTime>='2019-01-01') && (StartTime<='2019-12-31')].[SnapshotId]" --output text
 ```
 
 ------


### PR DESCRIPTION
The examples are incorrect, as backticks ` are evaluated on the cli.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
